### PR TITLE
NN-2246: Remove caseload options from dropdown, replaced with link to specific page

### DIFF
--- a/components/Dropdown/Dropdown.js
+++ b/components/Dropdown/Dropdown.js
@@ -1,21 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { getPrisonDescription, toFullName } from '../../utils'
-import {
-  MenuWrapper,
-  InfoWrapper,
-  UserName,
-  CaseLoad,
-  DropdownMenu,
-  DropdownMenuButton,
-  DropdownMenuLink,
-} from './Dropdown.styles'
+import { MenuWrapper, InfoWrapper, UserName, CaseLoad, DropdownMenu, DropdownMenuLink } from './Dropdown.styles'
 
 const createMenuOptionId = text => `menu-option-${text && text.replace(' ', '-')}`
 
-const Dropdown = ({ user, switchCaseLoad, history, menuOpen, setMenuOpen, extraLinks, caseChangeRedirect }) => {
+const Dropdown = ({ user, menuOpen, setMenuOpen, extraLinks }) => {
   const caseLoadDesc = getPrisonDescription(user)
-  const options = user.caseLoadOptions.filter(x => x.caseLoadId !== user.activeCaseLoadId)
 
   return (
     <MenuWrapper>
@@ -51,21 +42,6 @@ const Dropdown = ({ user, switchCaseLoad, history, menuOpen, setMenuOpen, extraL
                 {link.text}
               </DropdownMenuLink>
             ))}
-            {options.map(option => (
-              <DropdownMenuButton
-                type="button"
-                className="dropdown-menu-option"
-                id={`menu-option-${option.caseLoadId}`}
-                key={option.caseLoadId}
-                onClick={() => {
-                  setMenuOpen(false)
-                  switchCaseLoad(option.caseLoadId)
-                  if (caseChangeRedirect) history.push('/')
-                }}
-              >
-                {option.description}
-              </DropdownMenuButton>
-            ))}
             <DropdownMenuLink className="dropdown-menu-link" key="logout" href="/auth/logout">
               Sign out
             </DropdownMenuLink>
@@ -89,9 +65,6 @@ Dropdown.propTypes = {
   }),
   menuOpen: PropTypes.bool,
   setMenuOpen: PropTypes.func.isRequired,
-  switchCaseLoad: PropTypes.func.isRequired,
-  history: PropTypes.shape({ push: PropTypes.func.isRequired }).isRequired,
-  caseChangeRedirect: PropTypes.bool,
   extraLinks: PropTypes.arrayOf(
     PropTypes.shape({ url: PropTypes.string, text: PropTypes.string.isRequired, onclick: PropTypes.func })
   ),
@@ -106,7 +79,6 @@ Dropdown.defaultProps = {
   },
   menuOpen: false,
   extraLinks: [],
-  caseChangeRedirect: true,
 }
 
 export default Dropdown

--- a/components/Dropdown/Dropdown.styles.js
+++ b/components/Dropdown/Dropdown.styles.js
@@ -81,10 +81,6 @@ const linkStyle = css`
   }
 `
 
-export const DropdownMenuButton = styled('button')`
-  ${linkStyle};
-`
-
 export const DropdownMenuLink = styled('a')`
   ${linkStyle};
 `

--- a/components/Dropdown/Dropdown.test.js
+++ b/components/Dropdown/Dropdown.test.js
@@ -68,17 +68,10 @@ describe('Dropdown component', () => {
     })
 
     it('should render correctly', () => {
-      const dropdown = component.find('.dropdown-menu-option')
-      // Current id 'LEI' should be omitted
+      const dropdown = component.find('.dropdown-menu-link')
+
       expect(dropdown.length).toEqual(1)
-      expect(dropdown.get(0).props.children).toEqual('Shrewsbury (HMP)')
-    })
-
-    it('should handle the display of empty caseLoadOptions elegantly', () => {
-      component.setProps({ user: userWithEmptyCaseLoadOptions })
-
-      expect(component.find('.dropdown-menu-option')).toHaveLength(0)
-      expect(component.find('.dropdown-menu-link').get(0).props.children).toEqual('Sign out')
+      expect(dropdown.get(0).props.children).toEqual('Sign out')
     })
 
     it('should not display the active caseload when user does not have one', () => {
@@ -117,43 +110,9 @@ describe('Dropdown component', () => {
 
       expect(props.setMenuOpen).toHaveBeenCalledWith(false)
     })
-
-    it('should close the menu when clicked', () => {
-      component
-        .find('.dropdown-menu-option')
-        .at(0)
-        .prop('onClick')()
-
-      expect(props.setMenuOpen).toHaveBeenCalledWith(false)
-    })
   })
 
   describe('Dropdown menu items', () => {
-    it('should switch the case load when clicked', () => {
-      component
-        .find('.dropdown-menu-option')
-        .at(0)
-        .prop('onClick')()
-      expect(props.switchCaseLoad).toHaveBeenCalledWith('SYI')
-    })
-
-    it('should redirect back to the root of the application by default when clicked', () => {
-      component
-        .find('.dropdown-menu-option')
-        .at(0)
-        .prop('onClick')()
-      expect(props.history.push).toHaveBeenCalledWith('/')
-    })
-
-    it('should NOT redirect back to the root of the application if specified when clicked', () => {
-      component.setProps({ caseChangeRedirect: false })
-      component
-        .find('.dropdown-menu-option')
-        .at(0)
-        .prop('onClick')()
-      expect(props.history.push).not.toHaveBeenCalled()
-    })
-
     it('should setup extra links correctly', () => {
       const callBack = jest.fn()
       const extraLinks = [{ text: 'stuff' }, { url: '/route1', text: 'route1', onClick: callBack }]

--- a/components/Header/index.js
+++ b/components/Header/index.js
@@ -4,18 +4,7 @@ import Dropdown from '../Dropdown'
 import './header.scss'
 import '../common.scss'
 
-const Header = ({
-  homeLink,
-  logoText,
-  title,
-  user,
-  menuOpen,
-  setMenuOpen,
-  switchCaseLoad,
-  history,
-  caseChangeRedirect,
-  extraLinks,
-}) => (
+const Header = ({ homeLink, logoText, title, user, menuOpen, setMenuOpen, extraLinks }) => (
   <header className="page-header">
     <div className="header-content clickable">
       <div className="left-content">
@@ -33,15 +22,7 @@ const Header = ({
         <div className="right-menu">
           {user &&
             user.username && (
-              <Dropdown
-                user={user}
-                menuOpen={menuOpen}
-                setMenuOpen={setMenuOpen}
-                switchCaseLoad={switchCaseLoad}
-                history={history}
-                caseChangeRedirect={caseChangeRedirect}
-                extraLinks={extraLinks}
-              />
+              <Dropdown user={user} menuOpen={menuOpen} setMenuOpen={setMenuOpen} extraLinks={extraLinks} />
             )}
         </div>
       </div>
@@ -60,11 +41,8 @@ Header.propTypes = {
     activeCaseLoadId: PropTypes.string,
     isOpen: PropTypes.bool,
   }),
-  switchCaseLoad: PropTypes.func.isRequired,
-  history: PropTypes.shape({ push: PropTypes.func.isRequired }).isRequired,
   menuOpen: PropTypes.bool,
   setMenuOpen: PropTypes.func.isRequired,
-  caseChangeRedirect: PropTypes.bool,
   extraLinks: PropTypes.arrayOf(
     PropTypes.shape({ url: PropTypes.string, text: PropTypes.string.isRequired, onclick: PropTypes.func })
   ),
@@ -74,7 +52,6 @@ Header.defaultProps = {
   user: {},
   menuOpen: false,
   extraLinks: [],
-  caseChangeRedirect: true,
 }
 
 // noinspection JSUnusedGlobalSymbols


### PR DESCRIPTION
The dropdown of caseloads is being replaced with a link to a case load switcher page. Each app that uses this component will update accordingly.